### PR TITLE
Use of local variables instead of global vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,15 +4,16 @@ module.exports = function (filepath, split, encoding) {
   split = typeof split !== 'undefined' ? split : "\n";
   encoding = typeof encoding !== 'undefined' ? encoding : "utf8";
 
-  ca = [];
-  chain = fs.readFileSync(filepath, encoding);
+  var ca = [];
+  var chain = fs.readFileSync(filepath, encoding);
   if(chain.indexOf("-END CERTIFICATE-") < 0 || chain.indexOf("-BEGIN CERTIFICATE-") < 0){
     throw Error("File does not contain 'BEGIN CERTIFICATE' or 'END CERTIFICATE'");
   }
   chain = chain.split(split);
-  cert = [];
+  var cert = [];
+  var _i, _len;
   for (_i = 0, _len = chain.length; _i < _len; _i++) {
-    line = chain[_i];
+    var line = chain[_i];
     if (!(line.length !== 0)) {
       continue;
     }


### PR DESCRIPTION
You should use local variables in your lib instead of global vars. Some tools like Mocha are complaining about it.
